### PR TITLE
Implement basic route purchasing by card count

### DIFF
--- a/ticket-to-rio/src/Scenes/TestMap/Map.tscn
+++ b/ticket-to-rio/src/Scenes/TestMap/Map.tscn
@@ -4,3 +4,5 @@
 
 [node name="Map" type="Node2D"]
 script = ExtResource("1_1oylf")
+player_hand_path = NodePath("../PlayerHand")
+player_color = Color(0, 1, 0, 1)

--- a/ticket-to-rio/src/Scripts/components/route.gd
+++ b/ticket-to-rio/src/Scripts/components/route.gd
@@ -4,6 +4,7 @@ class_name Route
 @export var from_city_name: String = ""
 @export var to_city_name: String = ""
 @export var route_color: Color = Color.WHITE
+var route_color_name: String = ""
 @export var wagon_cost: int = 0
 @export var parallel_offset: float = 5.5
 @export var line_visual_width: float = 10.0
@@ -16,17 +17,21 @@ var wagon_sprite_scene: PackedScene = preload("res://src/Scenes/TestMap/WagonSpr
 var from_city_node: Node2D = null
 var to_city_node: Node2D = null
 
+var claimed: bool = false
+
 signal route_clicked(route_node)
 
 func _ready():
 	if area_2d:
 		area_2d.input_event.connect(_on_area_2d_input_event)
 		
-func setup_route(p_from_city: Node2D, p_to_city: Node2D, p_color: Color, p_cost: int):
-	from_city_node = p_from_city
-	to_city_node = p_to_city
-	route_color = p_color
-	wagon_cost = p_cost
+func setup_route(p_from_city: Node2D, p_to_city: Node2D, p_color: Color, p_cost: int, p_color_name: String = ""):
+        from_city_node = p_from_city
+        to_city_node = p_to_city
+        route_color = p_color
+        wagon_cost = p_cost
+        route_color_name = p_color_name
+        claimed = false
 
 	if not is_instance_valid(from_city_node) or not is_instance_valid(to_city_node):
 		printerr("Route setup: From or To city node is not valid.")


### PR DESCRIPTION
## Summary
- add player hand variables to `Map` and check cards before claiming
- track route color names and claimed state in `Route`
- allow paying for routes with cards and wilds
- set player hand path in the `Map` scene

## Testing
- `find . -maxdepth 3 -name '*test*' | head`


------
https://chatgpt.com/codex/tasks/task_e_6856dc5a47a88323b4d9ccfd2f0bb0a7